### PR TITLE
CTO-179: Filter records with no unit value and parameterize more config values

### DIFF
--- a/tests/features/test_generate.py
+++ b/tests/features/test_generate.py
@@ -3,9 +3,6 @@
 # Direct all questions to support@cloudzero.com
 
 import datetime
-import simplejson as json
-
-from string import Template
 
 from uca.features.generate import _render_uca_data
 

--- a/tests/features/test_generate.py
+++ b/tests/features/test_generate.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2021 CloudZero, Inc. All rights reserved.
+# Licensed under the BSD License. See LICENSE file in the project root for full license information.
+# Direct all questions to support@cloudzero.com
+
+import datetime
+import simplejson as json
+
+from string import Template
+
+from uca.features.generate import _render_uca_data
+
+
+def test_filter_nil_unit_values_exact_mode():
+    input_uca_data = [{'unit_id': 'Sunbank', 'unit_value': '0'},
+                      {'unit_id': 'SoftwareCorp', 'unit_value': '0'},
+                      {'unit_id': 'Parts, Inc.', 'unit_value': '0'},
+                      {'unit_id': 'Transport Co.', 'unit_value': '0'},
+                      {'unit_id': 'WeShipit, Inc.', 'unit_value': '0'},
+                      {'unit_id': 'CapitalTwo', 'unit_value': '0'},
+                      {'unit_id': 'Bank of Sokovia', 'unit_value': '0'},
+                      {'unit_id': 'Makers', 'unit_value': '0'},
+                      {'unit_id': 'StateEx', 'unit_value': '0'},
+                      {'unit_id': 'Flitter', 'unit_value': '0'},
+                      {'unit_id': 'Pets2you', 'unit_value': '0'},
+                      {'unit_id': 'Hooli', 'unit_value': '0'},
+                      {'unit_id': 'Massive Dynamic', 'unit_value': '1000'}]
+
+    input_settings = {'allocation': '', 'jitter': '', 'mode': 'exact'}
+
+    input_template = Template(json.dumps({'cost-context': 'Cost-Per-Fake-Customer',
+                                          'granularity': 'DAILY',
+                                          'id': '$unit_id',
+                                          'target': {},
+                                          'telemetry-stream': 'test-data',
+                                          'timestamp': '$timestamp',
+                                          'value': '$unit_value'}))
+
+    input_timestamp = datetime.datetime(2022, 10, 30, 0, 0)
+
+    result = _render_uca_data(input_uca_data, input_settings, input_template, input_timestamp)
+    assert len(result) == 1
+
+
+def test_filter_nil_unit_values_random_mode():
+    input_uca_data = [{'unit_id': 'Sunbank', 'unit_value': '0'},
+                      {'unit_id': 'SoftwareCorp', 'unit_value': '0'},
+                      {'unit_id': 'Parts, Inc.', 'unit_value': '0'},
+                      {'unit_id': 'Transport Co.', 'unit_value': '0'},
+                      {'unit_id': 'WeShipit, Inc.', 'unit_value': '0'},
+                      {'unit_id': 'CapitalTwo', 'unit_value': '0'},
+                      {'unit_id': 'Bank of Sokovia', 'unit_value': '0'},
+                      {'unit_id': 'Makers', 'unit_value': '0'},
+                      {'unit_id': 'StateEx', 'unit_value': '0'},
+                      {'unit_id': 'Flitter', 'unit_value': '0'},
+                      {'unit_id': 'Pets2you', 'unit_value': '0'},
+                      {'unit_id': 'Hooli', 'unit_value': '0'},
+                      {'unit_id': 'Massive Dynamic', 'unit_value': '1000'}]
+
+    input_settings = {'allocation': '', 'jitter': '', 'mode': 'random'}
+
+    input_template = Template(json.dumps({'cost-context': 'Cost-Per-Fake-Customer',
+                                          'granularity': 'DAILY',
+                                          'id': '$unit_id',
+                                          'target': {},
+                                          'telemetry-stream': 'test-data',
+                                          'timestamp': '$timestamp',
+                                          'value': '$unit_value'}))
+
+    input_timestamp = datetime.datetime(2022, 10, 30, 0, 0)
+
+    result = _render_uca_data(input_uca_data, input_settings, input_template, input_timestamp)
+    assert len(result) == 1

--- a/tests/features/test_generate.py
+++ b/tests/features/test_generate.py
@@ -27,13 +27,13 @@ def test_filter_nil_unit_values_exact_mode():
 
     input_settings = {'allocation': '', 'jitter': '', 'mode': 'exact'}
 
-    input_template = Template(json.dumps({'cost-context': 'Cost-Per-Fake-Customer',
-                                          'granularity': 'DAILY',
-                                          'id': '$unit_id',
-                                          'target': {},
-                                          'telemetry-stream': 'test-data',
+    input_template = {'cost-context': 'Cost-Per-Fake-Customer',
+                      'granularity': 'DAILY',
+                      'id': '$unit_id',
+                      'target': {},
+                      'telemetry-stream': 'test-data',
                                           'timestamp': '$timestamp',
-                                          'value': '$unit_value'}))
+                                          'value': '$unit_value'}
 
     input_timestamp = datetime.datetime(2022, 10, 30, 0, 0)
 
@@ -58,13 +58,13 @@ def test_filter_nil_unit_values_random_mode():
 
     input_settings = {'allocation': '', 'jitter': '', 'mode': 'random'}
 
-    input_template = Template(json.dumps({'cost-context': 'Cost-Per-Fake-Customer',
-                                          'granularity': 'DAILY',
-                                          'id': '$unit_id',
-                                          'target': {},
-                                          'telemetry-stream': 'test-data',
+    input_template = {'cost-context': 'Cost-Per-Fake-Customer',
+                      'granularity': 'DAILY',
+                      'id': '$unit_id',
+                      'target': {},
+                      'telemetry-stream': 'test-data',
                                           'timestamp': '$timestamp',
-                                          'value': '$unit_value'}))
+                                          'value': '$unit_value'}
 
     input_timestamp = datetime.datetime(2022, 10, 30, 0, 0)
 

--- a/uca/__version__.py
+++ b/uca/__version__.py
@@ -2,4 +2,4 @@
 # Licensed under the BSD License. See LICENSE file in the project root for full license information.
 # Direct all questions to support@cloudzero.com
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'

--- a/uca/common/cli.py
+++ b/uca/common/cli.py
@@ -74,6 +74,6 @@ def print_uca_sample(uca_to_send, record_count=5):
     sample_count = min(record_count, len(uca_to_send))
     sample_events = []
     print(f"\nSample of first {sample_count} and last {sample_count} UCA events post-processing:")
-    for x in {*range(0, record_count), *range(len(uca_to_send) - record_count, len(uca_to_send))}:
+    for x in {*range(0, sample_count), *range(len(uca_to_send) - sample_count, len(uca_to_send))}:
         sample_events.append([x, fill(str(uca_to_send[x]), 240)])
     print(tabulate(sample_events, headers=["#", "Event"], tablefmt="simple"))  # , maxcolwidths=[None, 140]))

--- a/uca/features/generate.py
+++ b/uca/features/generate.py
@@ -59,6 +59,9 @@ def _render_uca_data(uca_data, settings, template, timestamp=None):
 
     uca_events = []
     for row in uca_data:
+        if Decimal(row['unit_value']) <= 0:
+            continue
+
         if settings['mode'] == 'random':
             unit_value = preserve_precision(row['unit_value'], PRECISION)
             row['unit_value'] = str(restore_precision(randint(0, unit_value), PRECISION))
@@ -87,8 +90,7 @@ def _render_uca_data(uca_data, settings, template, timestamp=None):
         else:
             rendered_template = template.substitute(**row)
 
-        if Decimal(row['unit_value']) > 0:
-            uca_events.append(json.loads(rendered_template.strip().replace("\n", "")))
+        uca_events.append(json.loads(rendered_template.strip().replace("\n", "")))
 
     return uca_events
 


### PR DESCRIPTION
## Description of the change

> Allow users to use any column header name for unit_value and timestamp
> Filter records with nil values

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement

## Checklists

### Development
- [ ] All changed code has 80% unit test coverage
- [ ] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)

### Code review 
- [ ]  This pull request has a title that includes the JIRA Ticket and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.
