### PR TITLE
CP-15835: chore(github): Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cloudzero/open-source-maintainers
+*       @cloudzero/droptable


### PR DESCRIPTION
This PR adds a CODEOWNERS file to the repo, assigning ownership to [@cloudzero/droptable].