### PR TITLE
Issue #58: Removed Unnecessary Key-Value Pairs from Unit Cost API Request Payload 

### DIFF
--- a/docs/quick_starts/quick_start_allocation_telemetry/scenario_1.md
+++ b/docs/quick_starts/quick_start_allocation_telemetry/scenario_1.md
@@ -32,15 +32,15 @@
 {
     "version": "1",
     "template": {
-      "timestamp": "$timestamp",
+      "telemetry-stream": "product-cost-per-customer-v1",
       "granularity": "HOURLY",
-      "element-name": "$element_id",
       "filter": {
         "custom:$filter_dimension": [
           "$filter_dimension_group"
         ]
       },
-      "telemetry-stream": "product-cost-per-customer-v1",
+      "timestamp": "$timestamp",
+      "element-name": "$element_id",
       "value": "$unit_value"
     },
     "settings": {

--- a/docs/quick_starts/quick_start_allocation_telemetry/scenario_1.md
+++ b/docs/quick_starts/quick_start_allocation_telemetry/scenario_1.md
@@ -45,6 +45,7 @@
     },
     "settings": {
       "api_key": "<CLOUDZERO API KEY>",
+      "transmit_type": "sum",
       "generate": {"mode": "exact"}
     }
   }

--- a/docs/quick_starts/quick_start_allocation_telemetry/scenario_2.md
+++ b/docs/quick_starts/quick_start_allocation_telemetry/scenario_2.md
@@ -56,6 +56,7 @@ For example, if the time period is `2024-02-09 - 2024-02-10`, then every hour in
     },
     "settings": {
       "api_key": "<CLOUDZERO API KEY>",
+      "transmit_type": "sum",
       "generate": {"mode": "exact"}
     }
   }

--- a/docs/quick_starts/quick_start_allocation_telemetry/scenario_2.md
+++ b/docs/quick_starts/quick_start_allocation_telemetry/scenario_2.md
@@ -43,15 +43,15 @@ For example, if the time period is `2024-02-09 - 2024-02-10`, then every hour in
 {
     "version": "1",
     "template": {
-      "timestamp": "$timestamp",
+      "telemetry-stream": "product-cost-per-customer-v1",
       "granularity": "DAILY",
-      "element-name": "$element_id",
       "filter": {
         "custom:$filter_dimension": [
           "$filter_dimension_group"
         ]
       },
-      "telemetry-stream": "product-cost-per-customer-v1",
+      "timestamp": "$timestamp",
+      "element-name": "$element_id",
       "value": "$unit_value"
     },
     "settings": {

--- a/docs/quick_starts/quick_start_allocation_telemetry/scenario_3.md
+++ b/docs/quick_starts/quick_start_allocation_telemetry/scenario_3.md
@@ -38,15 +38,15 @@ Each value will have its own random `jitter`.
 {
   "version": "1",
   "template": {
-    "timestamp": "$timestamp",
+    "telemetry-stream": "product-cost-per-customer-v1",
     "granularity": "HOURLY",
-    "element-name": "$element_id",
     "filter": {
       "custom:$filter_dimension": [
         "$filter_dimension_group"
       ]
     },
-    "telemetry-stream": "product-cost-per-customer-v1",
+    "timestamp": "$timestamp",
+    "element-name": "$element_id",
     "value": "$unit_value"
   },
   "settings": {

--- a/docs/quick_starts/quick_start_allocation_telemetry/scenario_3.md
+++ b/docs/quick_starts/quick_start_allocation_telemetry/scenario_3.md
@@ -51,6 +51,7 @@ Each value will have its own random `jitter`.
   },
   "settings": {
     "api_key": "",
+    "transmit_type": "sum",
     "generate": {
       "mode": "jitter",
       "jitter": 10

--- a/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_1.md
+++ b/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_1.md
@@ -40,6 +40,7 @@
   },
   "settings": {
     "api_key": "<CLOUDZERO API KEY>",
+    "transmit_type": "sum",
     "generate": {
       "mode": "exact"
     }

--- a/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_1.md
+++ b/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_1.md
@@ -33,7 +33,7 @@
   "template": {
     "timestamp": "$timestamp",
     "granularity": "HOURLY",
-    "associated-cost": {
+    "associated_cost": {
       "custom:$filter_dimension_1": "$filter_dimension_1_group"
     },
     "metric-name": "cost-per-hourly-ad-impressions-v1",
@@ -59,16 +59,16 @@ uca -c unit-metric-config.json generate -o unit-metric-telemetry-records.json -i
 
 `unit-metric-telemetry-records.json`
 ```json
-{"timestamp": "2024-02-08 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "10000.00"}
-{"timestamp": "2024-02-08 01:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "10000.00"}
-{"timestamp": "2024-02-08 02:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "20000.00"}
-{"timestamp": "2024-02-08 03:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "30000.00"}
-{"timestamp": "2024-02-08 04:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "30000.00"}
-{"timestamp": "2024-02-08 05:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "10000.00"}
-{"timestamp": "2024-02-08 06:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "10000.00"}
-{"timestamp": "2024-02-08 07:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "20000.00"}
-{"timestamp": "2024-02-08 08:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "30000.00"}
-{"timestamp": "2024-02-08 09:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "30000.00"}
+{"timestamp": "2024-02-08 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "10000.00"}
+{"timestamp": "2024-02-08 01:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "10000.00"}
+{"timestamp": "2024-02-08 02:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "20000.00"}
+{"timestamp": "2024-02-08 03:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "30000.00"}
+{"timestamp": "2024-02-08 04:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "30000.00"}
+{"timestamp": "2024-02-08 05:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "10000.00"}
+{"timestamp": "2024-02-08 06:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "10000.00"}
+{"timestamp": "2024-02-08 07:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "20000.00"}
+{"timestamp": "2024-02-08 08:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "30000.00"}
+{"timestamp": "2024-02-08 09:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-hourly-ad-impressions-v1", "value": "30000.00"}
 ```
 
 [Previous Page: Explanation of Unit Metric Data](./explanation_of_unit_metric_data.md) | [Next Page: Quick Start Scenario 2](./scenario_2.md)

--- a/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_1.md
+++ b/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_1.md
@@ -31,12 +31,11 @@
 {
   "version": "1",
   "template": {
-    "timestamp": "$timestamp",
-    "granularity": "HOURLY",
+    "metric-name": "cost-per-hourly-ad-impressions-v1",
     "associated_cost": {
       "custom:$filter_dimension_1": "$filter_dimension_1_group"
     },
-    "metric-name": "cost-per-hourly-ad-impressions-v1",
+    "timestamp": "$timestamp",
     "value": "$unit_value"
   },
   "settings": {

--- a/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_2.md
+++ b/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_2.md
@@ -44,7 +44,7 @@ For example, if the time period is `2024-02-09 - 2024-02-10`, then every hour in
   "template": {
     "timestamp": "$timestamp",
     "granularity": "DAILY",
-    "associated-cost": {
+    "associated_cost": {
       "custom:$filter_dimension_1": "$filter_dimension_1_group"
     },
     "metric-name": "cost-per-daily-ad-impressions-v1",
@@ -70,26 +70,26 @@ uca -c unit-metric-config.json generate -o unit-metric-telemetry-records.json -i
 
 `unit-metric-telemetry-records.json`
 ```json
-{"timestamp": "2024-02-09 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "10000.00"}
-{"timestamp": "2024-02-09 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "10000.00"}
-{"timestamp": "2024-02-09 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "20000.00"}
-{"timestamp": "2024-02-09 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "30000.00"}
-{"timestamp": "2024-02-09 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "30000.00"}
-{"timestamp": "2024-02-09 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "10000.00"}
-{"timestamp": "2024-02-09 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "10000.00"}
-{"timestamp": "2024-02-09 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "20000.00"}
-{"timestamp": "2024-02-09 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "30000.00"}
-{"timestamp": "2024-02-09 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "30000.00"}
-{"timestamp": "2024-02-10 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "10000.00"}
-{"timestamp": "2024-02-10 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "10000.00"}
-{"timestamp": "2024-02-10 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "20000.00"}
-{"timestamp": "2024-02-10 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "30000.00"}
-{"timestamp": "2024-02-10 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "30000.00"}
-{"timestamp": "2024-02-10 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "10000.00"}
-{"timestamp": "2024-02-10 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "10000.00"}
-{"timestamp": "2024-02-10 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "20000.00"}
-{"timestamp": "2024-02-10 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "30000.00"}
-{"timestamp": "2024-02-10 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "30000.00"}
+{"timestamp": "2024-02-09 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "10000.00"}
+{"timestamp": "2024-02-09 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "10000.00"}
+{"timestamp": "2024-02-09 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "20000.00"}
+{"timestamp": "2024-02-09 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "30000.00"}
+{"timestamp": "2024-02-09 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "30000.00"}
+{"timestamp": "2024-02-09 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "10000.00"}
+{"timestamp": "2024-02-09 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "10000.00"}
+{"timestamp": "2024-02-09 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "20000.00"}
+{"timestamp": "2024-02-09 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "30000.00"}
+{"timestamp": "2024-02-09 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "30000.00"}
+{"timestamp": "2024-02-10 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "10000.00"}
+{"timestamp": "2024-02-10 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "10000.00"}
+{"timestamp": "2024-02-10 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "20000.00"}
+{"timestamp": "2024-02-10 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "30000.00"}
+{"timestamp": "2024-02-10 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "30000.00"}
+{"timestamp": "2024-02-10 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "10000.00"}
+{"timestamp": "2024-02-10 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "10000.00"}
+{"timestamp": "2024-02-10 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "20000.00"}
+{"timestamp": "2024-02-10 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "30000.00"}
+{"timestamp": "2024-02-10 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "cost-per-daily-ad-impressions-v1", "value": "30000.00"}
 ```
 
 [Previous Page: Quick Start Scenario 1](./scenario_1.md) | [Next Page: Quick Start Scenario 3](./scenario_3.md)

--- a/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_2.md
+++ b/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_2.md
@@ -42,12 +42,11 @@ For example, if the time period is `2024-02-09 - 2024-02-10`, then every hour in
 {
   "version": "1",
   "template": {
-    "timestamp": "$timestamp",
-    "granularity": "DAILY",
+    "metric-name": "cost-per-hourly-ad-impressions-v1",
     "associated_cost": {
       "custom:$filter_dimension_1": "$filter_dimension_1_group"
     },
-    "metric-name": "cost-per-daily-ad-impressions-v1",
+    "timestamp": "$timestamp",
     "value": "$unit_value"
   },
   "settings": {

--- a/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_2.md
+++ b/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_2.md
@@ -51,6 +51,7 @@ For example, if the time period is `2024-02-09 - 2024-02-10`, then every hour in
   },
   "settings": {
     "api_key": "<CLOUDZERO API KEY>",
+    "transmit_type": "sum",
     "generate": {
       "mode": "exact"
     }

--- a/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_3.md
+++ b/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_3.md
@@ -39,7 +39,7 @@ Each value will have its own random `jitter`.
   "template": {
     "timestamp": "$timestamp",
     "granularity": "HOURLY",
-    "associated-cost": {
+    "associated_cost": {
       "custom:$filter_dimension_1": "$filter_dimension_1_group"
     },
     "metric-name": "cost-per-hourly-ad-impressions-v1",
@@ -66,16 +66,16 @@ uca -c unit-metric-config.json generate -o unit-metric-telemetry-records.json -i
 
 `unit-metric-telemetry-records.json`
 ```json
-{"timestamp": "2024-02-08 00:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "10151.00"}
-{"timestamp": "2024-02-08 01:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "9165.00"}
-{"timestamp": "2024-02-08 02:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "20789.00"}
-{"timestamp": "2024-02-08 03:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "29937.00"}
-{"timestamp": "2024-02-08 04:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "30221.00"}
-{"timestamp": "2024-02-08 05:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "10132.00"}
-{"timestamp": "2024-02-08 06:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "9624.00"}
-{"timestamp": "2024-02-08 07:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "20063.00"}
-{"timestamp": "2024-02-08 08:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "30876.00"}
-{"timestamp": "2024-02-08 09:00:00+00:00", "associated-cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "29353.00"}
+{"timestamp": "2024-02-08 00:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "10151.00"}
+{"timestamp": "2024-02-08 01:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "9165.00"}
+{"timestamp": "2024-02-08 02:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "20789.00"}
+{"timestamp": "2024-02-08 03:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "29937.00"}
+{"timestamp": "2024-02-08 04:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "30221.00"}
+{"timestamp": "2024-02-08 05:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "10132.00"}
+{"timestamp": "2024-02-08 06:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "9624.00"}
+{"timestamp": "2024-02-08 07:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "20063.00"}
+{"timestamp": "2024-02-08 08:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "30876.00"}
+{"timestamp": "2024-02-08 09:00:00+00:00", "associated_cost": {"custom:product": "product A"}, "metric-name": "hourly-cost-per-ad-impression-v1", "value": "29353.00"}
 
 ```
 

--- a/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_3.md
+++ b/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_3.md
@@ -46,6 +46,7 @@ Each value will have its own random `jitter`.
   },
   "settings": {
     "api_key": "<CLOUDZERO API KEY>",
+    "transmit_type": "sum",
     "generate": {
       "mode": "jitter",
       "jitter": 1000

--- a/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_3.md
+++ b/docs/quick_starts/quick_start_unit_metric_telemetry/scenario_3.md
@@ -37,12 +37,11 @@ Each value will have its own random `jitter`.
 {
   "version": "1",
   "template": {
-    "timestamp": "$timestamp",
-    "granularity": "HOURLY",
+    "metric-name": "cost-per-hourly-ad-impressions-v1",
     "associated_cost": {
       "custom:$filter_dimension_1": "$filter_dimension_1_group"
     },
-    "metric-name": "cost-per-hourly-ad-impressions-v1",
+    "timestamp": "$timestamp",
     "value": "$unit_value"
   },
   "settings": {

--- a/uca/__version__.py
+++ b/uca/__version__.py
@@ -2,4 +2,4 @@
 #  SPDX-License-Identifier: Apache-2.0
 #  Direct all questions to support@cloudzero.com
 
-__version__ = '0.7.6'
+__version__ = '0.7.7'

--- a/uca/features/generate.py
+++ b/uca/features/generate.py
@@ -66,6 +66,9 @@ def generate_uca(time_range: TimeRange, uca_template, settings, uca_data):
 
 
 def _render_uca_data(uca_data, settings, uca_template, timestamp=None):
+    uca_template.pop("telemetry-stream", "None")
+    uca_template.pop("metric-name", "None")
+
     unit_value_header = uca_template['value'].replace('$', '')
     timestamp_header = uca_template['timestamp'].replace('$', '')
 

--- a/uca/features/generate.py
+++ b/uca/features/generate.py
@@ -21,20 +21,22 @@ PRECISION = 10000
 
 def generate_uca(time_range: TimeRange, uca_template, settings, uca_data):
     expand_month = False
-    if uca_template['granularity'] == "HOURLY":
-        delta = timedelta(hours=1)
-    elif uca_template['granularity'] == "DAILY":
-        delta = timedelta(days=1)
-    elif uca_template['granularity'] == "MONTHLY":
-        delta = timedelta(days=1)
-        uca_template['granularity'] = "DAILY"
-        expand_month = True
-    else:
-        eprint(f"Granularity {uca_template['granularity']} not supported")
-        sys.exit(-1)
 
     if "metric-name" in uca_template:
-        del uca_template["granularity"]
+        delta = timedelta(days=1)
+
+    else:
+        if uca_template['granularity'] == "HOURLY":
+            delta = timedelta(hours=1)
+        elif uca_template['granularity'] == "DAILY":
+            delta = timedelta(days=1)
+        elif uca_template['granularity'] == "MONTHLY":
+            delta = timedelta(days=1)
+            uca_template['granularity'] = "DAILY"
+            expand_month = True
+        else:
+            eprint(f"Granularity {uca_template['granularity']} not supported")
+            sys.exit(-1)
 
     uca_events = []
     if time_range:

--- a/uca/features/transmit.py
+++ b/uca/features/transmit.py
@@ -8,7 +8,7 @@ from uca.common.files import write_to_file
 from uca.interfaces.uca_api import send_uca_events
 
 
-def transmit(uca_to_send, output_file, api_key, dry_run):
+def transmit(stream_name, stream_type, uca_to_send, output_file, api_key, dry_run):
     # order maters here, we want dry run to come first, if not that, output to file, if not that api key
     if dry_run:
         print('\nDry run, exiting')
@@ -18,9 +18,10 @@ def transmit(uca_to_send, output_file, api_key, dry_run):
         print(f'\nWrote results to {output_file}')
     elif api_key:
         print('\nSending to API')
-        if "metric-name" in uca_to_send[0]:
-            send_uca_events(api_key, uca_to_send, telemetry_type="unit-metric")
+        if "metric-name" == stream_type:
+            send_uca_events(stream_name, api_key, uca_to_send, telemetry_type="unit-metric")
 
-        send_uca_events(api_key, uca_to_send)
+        elif "telemetry-stream" == stream_type:
+            send_uca_events(stream_name, api_key, uca_to_send)
     else:
         print('\nFinished, nothing to do')

--- a/uca/features/transmit.py
+++ b/uca/features/transmit.py
@@ -8,7 +8,7 @@ from uca.common.files import write_to_file
 from uca.interfaces.uca_api import send_uca_events
 
 
-def transmit(stream_name, stream_type, uca_to_send, output_file, api_key, dry_run):
+def transmit(stream_name, stream_type, transmit_type, uca_to_send, output_file, api_key, dry_run):
     # order maters here, we want dry run to come first, if not that, output to file, if not that api key
     if dry_run:
         print('\nDry run, exiting')
@@ -18,7 +18,7 @@ def transmit(stream_name, stream_type, uca_to_send, output_file, api_key, dry_ru
         print(f'\nWrote results to {output_file}')
     elif api_key:
         print('\nSending to API')
-        send_uca_events(stream_name, stream_type, api_key, uca_to_send)
+        send_uca_events(stream_name, stream_type, transmit_type, api_key, uca_to_send)
 
     else:
         print('\nFinished, nothing to do')

--- a/uca/features/transmit.py
+++ b/uca/features/transmit.py
@@ -18,10 +18,7 @@ def transmit(stream_name, stream_type, uca_to_send, output_file, api_key, dry_ru
         print(f'\nWrote results to {output_file}')
     elif api_key:
         print('\nSending to API')
-        if "metric-name" == stream_type:
-            send_uca_events(stream_name, api_key, uca_to_send, telemetry_type="unit-metric")
+        send_uca_events(stream_name, stream_type, api_key, uca_to_send)
 
-        elif "telemetry-stream" == stream_type:
-            send_uca_events(stream_name, api_key, uca_to_send)
     else:
         print('\nFinished, nothing to do')

--- a/uca/interfaces/uca_api.py
+++ b/uca/interfaces/uca_api.py
@@ -12,12 +12,12 @@ from uca.common.formatters import chunks
 from uca.constants import UCA_API_BATCH_SIZE
 
 
-def send_uca_events(stream_name, stream_type, api_key, uca_events):
+def send_uca_events(stream_name, stream_type, transmit_type, api_key, uca_events):
     print(
-        f"Sending {len(uca_events)} {stream_type} events to UCA API in {max(ceil(len(uca_events) / UCA_API_BATCH_SIZE), 1)} transaction(s)"
+        f"Sending {len(uca_events)} {stream_type} events to {transmit_type.upper()} UCA API in {max(ceil(len(uca_events) / UCA_API_BATCH_SIZE), 1)} transaction(s)"
     )
 
-    url = f"https://api.cloudzero.com/unit-cost/v1/telemetry/{stream_type}/{stream_name}/sum"
+    url = f"https://api.cloudzero.com/unit-cost/v1/telemetry/{stream_type}/{stream_name}/{transmit_type}"
 
     for chunk in chunks(uca_events, UCA_API_BATCH_SIZE):
         payload = {"records": chunk}

--- a/uca/interfaces/uca_api.py
+++ b/uca/interfaces/uca_api.py
@@ -12,15 +12,12 @@ from uca.common.formatters import chunks
 from uca.constants import UCA_API_BATCH_SIZE
 
 
-def send_uca_events(stream_name, api_key, uca_events, telemetry_type="allocation"):
+def send_uca_events(stream_name, stream_type, api_key, uca_events):
     print(
-        f"Sending {len(uca_events)} {telemetry_type} events to UCA API in {max(ceil(len(uca_events) / UCA_API_BATCH_SIZE), 1)} transaction(s)"
+        f"Sending {len(uca_events)} {stream_type} events to UCA API in {max(ceil(len(uca_events) / UCA_API_BATCH_SIZE), 1)} transaction(s)"
     )
 
-    if telemetry_type == "allocation":
-        url = f"https://api.cloudzero.com/unit-cost/v1/telemetry/allocation/{stream_name}"
-    else:
-        url = f"https://api.cloudzero.com/unit-cost/v1/telemetry/metric/{stream_name}"
+    url = f"https://api.cloudzero.com/unit-cost/v1/telemetry/{stream_type}/{stream_name}/sum"
 
     for chunk in chunks(uca_events, UCA_API_BATCH_SIZE):
         payload = {"records": chunk}

--- a/uca/interfaces/uca_api.py
+++ b/uca/interfaces/uca_api.py
@@ -12,15 +12,15 @@ from uca.common.formatters import chunks
 from uca.constants import UCA_API_BATCH_SIZE
 
 
-def send_uca_events(api_key, uca_events, telemetry_type="allocation"):
+def send_uca_events(stream_name, api_key, uca_events, telemetry_type="allocation"):
     print(
         f"Sending {len(uca_events)} {telemetry_type} events to UCA API in {max(ceil(len(uca_events) / UCA_API_BATCH_SIZE), 1)} transaction(s)"
     )
 
     if telemetry_type == "allocation":
-        url = f"https://api.cloudzero.com/unit-cost/v1/telemetry/allocation/{uca_events[0]['telemetry-stream']}"
+        url = f"https://api.cloudzero.com/unit-cost/v1/telemetry/allocation/{stream_name}"
     else:
-        url = f"https://api.cloudzero.com/unit-cost/v1/telemetry/metric/{uca_events[0]['metric-name']}"
+        url = f"https://api.cloudzero.com/unit-cost/v1/telemetry/metric/{stream_name}"
 
     for chunk in chunks(uca_events, UCA_API_BATCH_SIZE):
         payload = {"records": chunk}

--- a/uca/main.py
+++ b/uca/main.py
@@ -256,7 +256,11 @@ def transmit_uca_command(configuration, data, output, transform):
 
         if configuration.settings["transmit_type"] == "delete":
             for record in uca_to_send:
-                del record["value"]
+                try:
+                    del record["value"]
+
+                except KeyError:
+                    pass
 
     print(
         f" - Processed {len(records)} records "
@@ -265,9 +269,9 @@ def transmit_uca_command(configuration, data, output, transform):
     print(f" - {len(records) - filtered_records} records ready for transmission")
     print_uca_sample(uca_to_send)
     transmit(
-        stream_name,
-        stream_type,
-        transmit_type,
+        stream_name.lower(),
+        stream_type.lower(),
+        transmit_type.lower(),
         uca_to_send,
         configuration.output_path,
         configuration.api_key,
@@ -312,6 +316,17 @@ def convert_uca_command(configuration, data, output):
 
     print(f"\n - Writing UCA data to {output}")
     write_to_file(converted_data, output)
+
+
+@cli.command("delete-stream")
+@click.option(
+    "--stream",
+    "-s",
+    required=True,
+    help="Name of a CloudZero telemetry stream",
+)
+def delete_telemetry_stream(stream):
+    print(stream)
 
 
 if __name__ == "__main__":

--- a/uca/main.py
+++ b/uca/main.py
@@ -241,10 +241,6 @@ def transmit_uca_command(configuration, data, output, transform):
         print("Missing 'telemetry-stream' or 'metric-name' key in 'template' config:")
         sys.exit(-1)
 
-    transmit_type = "sum"
-    if "transmit_type" in configuration.settings:
-        transmit_type = configuration.settings["transmit_type"]
-        
     print(f"Transmitting UCA data from {data} to {configuration.destination}")
     print("-" * 140)
 
@@ -253,6 +249,15 @@ def transmit_uca_command(configuration, data, output, transform):
     uca_to_send, transformed_records, filtered_records = transform_data(
         records, transform_script
     )
+
+    transmit_type = "sum"
+    if "transmit_type" in configuration.settings:
+        transmit_type = configuration.settings["transmit_type"]
+
+        if configuration.settings["transmit_type"] == "delete":
+            for record in uca_to_send:
+                del record["value"]
+
     print(
         f" - Processed {len(records)} records "
         f"| {transformed_records} Transformed | {filtered_records} Filtered"

--- a/uca/main.py
+++ b/uca/main.py
@@ -156,7 +156,8 @@ def generate_uca_command(configuration, start, end, today, input, output):
         print("CloudZero UCA Data Generator")
         print("-" * 140)
         print(f"   Date Range : {range_requested or 'data driven'}")
-        print(f"  Granularity : {configuration.template['granularity']}")
+        if "metric-name" not in configuration.template:
+            print(f"  Granularity : {configuration.template['granularity']}")
         print(f"         Mode : {generate_settings['mode']}")
         if generate_settings["mode"] == "jitter":
             print(f"       Jitter : {generate_settings['jitter']}")

--- a/uca/main.py
+++ b/uca/main.py
@@ -230,11 +230,11 @@ def transmit_uca_command(configuration, data, output, transform):
 
     if 'telemetry-stream' in configuration.template:
         stream_name = configuration.template['telemetry-stream']
-        stream_type = 'telemetry-stream'
+        stream_type = 'allocation'
 
     elif 'metric-name' in configuration.template:
         stream_name = configuration.template['metric-name']
-        stream_type = 'metric-name'
+        stream_type = 'metric'
 
     else:
         print("Missing 'telemetry-stream' or 'metric-name' key in 'template' config:")

--- a/uca/main.py
+++ b/uca/main.py
@@ -227,6 +227,19 @@ def transmit_uca_command(configuration, data, output, transform):
     if output:
         configuration.output_path = output
         configuration.destination = "File"
+
+    if 'telemetry-stream' in configuration.template:
+        stream_name = configuration.template['telemetry-stream']
+        stream_type = 'telemetry-stream'
+
+    elif 'metric-name' in configuration.template:
+        stream_name = configuration.template['metric-name']
+        stream_type = 'metric-name'
+
+    else:
+        print("Missing 'telemetry-stream' or 'metric-name' key in 'template' config:")
+        sys.exit(-1)
+
     print(f"Transmitting UCA data from {data} to {configuration.destination}")
     print("-" * 140)
 
@@ -242,6 +255,8 @@ def transmit_uca_command(configuration, data, output, transform):
     print(f" - {len(records) - filtered_records} records ready for transmission")
     print_uca_sample(uca_to_send)
     transmit(
+        stream_name,
+        stream_type,
         uca_to_send,
         configuration.output_path,
         configuration.api_key,

--- a/uca/main.py
+++ b/uca/main.py
@@ -241,6 +241,10 @@ def transmit_uca_command(configuration, data, output, transform):
         print("Missing 'telemetry-stream' or 'metric-name' key in 'template' config:")
         sys.exit(-1)
 
+    transmit_type = "sum"
+    if "transmit_type" in configuration.settings:
+        transmit_type = configuration.settings["transmit_type"]
+        
     print(f"Transmitting UCA data from {data} to {configuration.destination}")
     print("-" * 140)
 
@@ -258,6 +262,7 @@ def transmit_uca_command(configuration, data, output, transform):
     transmit(
         stream_name,
         stream_type,
+        transmit_type,
         uca_to_send,
         configuration.output_path,
         configuration.api_key,

--- a/uca/main.py
+++ b/uca/main.py
@@ -251,7 +251,7 @@ def transmit_uca_command(configuration, data, output, transform):
     )
 
     transmit_type = "sum"
-    if "transmit_type" in configuration.settings:
+    if "transmit_type" in configuration.settings and configuration.settings["transmit_type"].lower() in ["sum", "update", "delete"]:
         transmit_type = configuration.settings["transmit_type"]
 
         if configuration.settings["transmit_type"] == "delete":


### PR DESCRIPTION
## Description of the change

> Removed the `telemetry-stream` and `metric-name` key-value pairs from Unit Cost API request payload
> Adjust the Unit Cost API payload based on stream type
> Fix `associated_cost` key in Unit Metric Telemetry docs

## Type of change
- [x] Bug fix
- [x] New feature

## Checklists

### Development
- [ ] All changed code has 80% unit test coverage
- [ ] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)

### Code review 
- [ ]  This pull request has a title that includes the JIRA Ticket and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.
